### PR TITLE
Use ivy to download antlr

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+/bin/
+/lib/
+/examples/sanka/

--- a/build.xml
+++ b/build.xml
@@ -1,9 +1,20 @@
-<project name="sanka" default="compile">
+<project name="sanka" default="compile"
+         xmlns:ivy="antlib:org.apache.ivy.ant">
+
+  <path id="classpath">
+    <fileset dir="lib"/>
+  </path>
+
+  <target name="resolve" description="retreive dependencies with ivy">
+    <ivy:retrieve/>
+  </target>
+
   <target name="compile">
     <mkdir dir="bin"/>
     <javac srcdir="src" destdir="bin" debug="on"
-           classpath="/usr/share/java/antlr4-runtime.jar"/>
+           classpathref="classpath"/>
   </target>
+
   <target name="jar" depends="compile">
     <jar destfile="bin/sanka.jar" basedir="bin" includes="sanka/**"/>
   </target>

--- a/ivy.xml
+++ b/ivy.xml
@@ -1,0 +1,6 @@
+<ivy-module version="2.0">
+  <info organisation="sanka" module="sanka"/>
+  <dependencies>
+    <dependency org="org.antlr" name="antlr4" rev="4.7.1" />
+  </dependencies>
+</ivy-module>


### PR DESCRIPTION
With this commit, to build, you first need to either `ant resolve` or, if you prefer, manually create a "lib" directory and put the antlr4 library into it.  The build script will no longer pick up libraries from /usr/share/java.

Add .gitignore file to tell git to ignore the output directories.