### PR TITLE
Use antlr4 version 4.5.1, via ivy.

### DIFF
--- a/.classpath
+++ b/.classpath
@@ -2,6 +2,6 @@
 <classpath>
 	<classpathentry kind="src" path="src"/>
 	<classpathentry kind="output" path="bin"/>
-	<classpathentry kind="lib" path="/usr/share/java/antlr4-runtime.jar"/>
+	<classpathentry kind="lib" path="lib/antlr4-runtime-4.5.1.jar"/>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER"/>
 </classpath>

--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,7 @@ INCLUDES=rb.h \
 CC=		gcc
 DBG=		-g
 CFLAGS=		$(DBG) -Iruntime
-ANTLR_RUNTIME=	/usr/share/java/antlr4-runtime.jar
+ANTLR_RUNTIME=	lib/antlr4-runtime-4.5.1.jar
 
 all:	bin/sanka.jar bin/sanka.sh bin/libsankaruntime.a
 
@@ -41,7 +41,7 @@ bin/sanka.jar:
 
 bin/sanka.sh:
 	echo '#!/bin/sh' > $@
-	echo exec java -cp ${PREFIX}/share/sanka.jar:$(ANTLR_RUNTIME) \
+	echo exec java -cp ${PREFIX}/share/sanka.jar:$(PREFIX)/$(ANTLR_RUNTIME) \
 	sanka/Translator -I ${PREFIX}/include '"$$@"' >> $@
 	chmod 755 $@
 
@@ -67,6 +67,9 @@ bin/System.o:		runtime/sanka/lang/System.c
 clean:
 	rm -rf bin *~
 
+allclean:	clean
+	rm -rf $(PREFIX)/*
+
 install: all
 	mkdir -p $(PREFIX)/bin
 	mkdir -p $(PREFIX)/include
@@ -74,5 +77,6 @@ install: all
 	mkdir -p $(PREFIX)/share
 	cp bin/sanka.sh $(PREFIX)/bin/sanka
 	cp bin/libsankaruntime.a $(PREFIX)/lib/
+	cp ${ANTLR_RUNTIME} $(PREFIX)/lib/
 	cp bin/sanka.jar $(PREFIX)/share/
 	cd runtime; tar cf - $(INCLUDES) | (cd $(PREFIX)/include; tar xf -)

--- a/build.xml
+++ b/build.xml
@@ -5,7 +5,7 @@
     <fileset dir="lib"/>
   </path>
 
-  <target name="resolve" description="retreive dependencies with ivy">
+  <target name="resolve" description="retrieve dependencies with ivy">
     <ivy:retrieve/>
   </target>
 
@@ -15,7 +15,7 @@
            classpathref="classpath"/>
   </target>
 
-  <target name="jar" depends="compile">
+  <target name="jar" depends="resolve, compile">
     <jar destfile="bin/sanka.jar" basedir="bin" includes="sanka/**"/>
   </target>
 </project>

--- a/ivy.xml
+++ b/ivy.xml
@@ -1,6 +1,7 @@
 <ivy-module version="2.0">
   <info organisation="sanka" module="sanka"/>
   <dependencies>
-    <dependency org="org.antlr" name="antlr4" rev="4.7.1" />
+    <dependency org="org.antlr" name="antlr4" rev="4.5.1" />
+    <dependency org="org.antlr" name="antlr4-runtime" rev="4.5.1" />
   </dependencies>
 </ivy-module>


### PR DESCRIPTION
- change version in ivy.xml from 4.7.1 to 4.5.1, to match what was used in building the spec
  - (old version appears to need separate targets for runtime and full versions)
- have library copied from <repo>/lib into <sanka-install>/lib
- have generated shell script add <sanka-install>/lib/<antlr> to classpath
- have ant "jar" target invoke ivy to download library
- add allclean Makefile target to get clean install
- fix typo in ant file
